### PR TITLE
Enabling faster acquisition rate

### DIFF
--- a/dpscope/controller/helper/acquisition_rate.py
+++ b/dpscope/controller/helper/acquisition_rate.py
@@ -20,7 +20,13 @@ class AcquisitionRate(object):
     # Acquisition rate options. dict key controls what gets shown in the view
     # option menu. dict value is the time period spanned across a division
     # in the data plot.
-    _rate_options = {"100 ms/div": 100,
+    _rate_options = {"1 ms/div": 1,
+                     "2 ms/div": 2,
+                     "5 ms/div": 5,
+                     "10 ms/div": 10,
+                     "20 ms/div": 20,
+                     "50 ms/div": 50,
+                     "100 ms/div": 100,
                      "200 ms/div": 200,
                      "500 ms/div": 500,
                      "1 s/div": 1000}

--- a/dpscope/model/controller/helper/voltage_measure.py
+++ b/dpscope/model/controller/helper/voltage_measure.py
@@ -209,6 +209,7 @@ class VoltageStreamer(object):
             period_ms (int, float): Time period in ms.
         """
         self._thread_runner.period_ms = period_ms
+        _LOGGER.info("Voltage streaming period {}ms.".format(period_ms))
 
     def voltage_reader_set(self, voltage_reader):
         """

--- a/dpscope/view/helper/queue_getter.py
+++ b/dpscope/view/helper/queue_getter.py
@@ -50,8 +50,12 @@ class TkQueueGetter(object):
     def period_ms(self, period_ms):
         """
         Sets looping periodicity in concurrent function as float.
+
+        The minimum periodicity is 10ms since Tkinter can't handle
+        refreshing at high rate.
         """
-        self._period_ms = float(period_ms)
+        self._period_ms = max(period_ms, 10.0)
+        _LOGGER.info("View refresh rate set at {}ms.".format(self._period_ms))
 
     @property
     def window(self):


### PR DESCRIPTION
- Decoupled view refresh rate from measurement rate.
- View refresh periodicity has minimum value of 10ms.