### PR TITLE
Voltage gain

### DIFF
--- a/dpscope/controller/app.py
+++ b/dpscope/controller/app.py
@@ -6,7 +6,7 @@ This is the controller from the MVC design pattern.
 import logging
 
 from controller.helper.acquisition_rate import AcquisitionRate
-from controller.helper.gain_setting import GainOptions
+from controller.helper.gain_setting import GainManager
 from controller.observer import observers_get_all
 from model.controller import DPScopeController
 from portselect import get_port
@@ -32,7 +32,7 @@ class DPScopeApp(object):
         Builds a standard view.
         """
         view_builder = Director(StandardViewBuilder(AcquisitionRate(),
-                                                    GainOptions()))
+                                                    GainManager()))
         view_builder.view_build()
         self._view = view_builder.view_get()
 

--- a/dpscope/controller/app.py
+++ b/dpscope/controller/app.py
@@ -6,6 +6,7 @@ This is the controller from the MVC design pattern.
 import logging
 
 from controller.helper.acquisition_rate import AcquisitionRate
+from controller.helper.gain_setting import GainOptions
 from controller.observer import observers_get_all
 from model.controller import DPScopeController
 from portselect import get_port
@@ -30,7 +31,8 @@ class DPScopeApp(object):
         """
         Builds a standard view.
         """
-        view_builder = Director(StandardViewBuilder(AcquisitionRate()))
+        view_builder = Director(StandardViewBuilder(AcquisitionRate(),
+                                                    GainOptions()))
         view_builder.view_build()
         self._view = view_builder.view_get()
 

--- a/dpscope/controller/helper/gain_setting.py
+++ b/dpscope/controller/helper/gain_setting.py
@@ -1,0 +1,132 @@
+"""
+Controls how gain options are shown in view, and converted into gain and
+pre-gain settings for DPScope.
+"""
+import logging
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG)
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
+
+
+class GainSetting(object):
+    """
+    Contains information on an individual gain setting.
+    """
+    display_str = None  # Text to display in view
+    pregain = None  # Pregain setting in circuit
+    gain = None  # Gain setting in circuit
+    mV_per_div = None  # mV per division in plot
+
+    _nominal_vcc = 5.  # Nominal usb voltage
+    _scale_down = 4.  # Scaling ratio from the first pot divider in circuit
+
+    @property
+    def cumulative_gain(self):
+        """
+        Returns:
+            int: Total gain factor from combination of pregain and gain in
+            the circuit.
+        """
+        return self.gain * self.pregain
+
+    @property
+    def voltage_max(self):
+        """
+        Returns:
+            float: Max voltage that can be measured given the current settings.
+        """
+        return self._nominal_vcc * self._scale_down / self.cumulative_gain
+
+    def __init__(self, display_str, mV_per_div, pregain, gain):
+        """
+        Instantiate settings for an individual gain option.
+
+        Args:
+            display_str (str): Display name of this gain setting in view.
+            mV_per_div (int, float): mV per division in plot view.
+            pregain (int): Pregain factor in circuit.
+            gain (int): Gain factor in circuit.
+        """
+        self.display_str = display_str
+        self.mV_per_div = float(mV_per_div)
+        self.pregain = pregain
+        self.gain = gain
+
+    def add_to_gain_options(self, gain_manager):
+        """
+        Add the current gain setting to the gain manager.
+
+        Args:
+            gain_manager (GainOptions): The gain manager that holds all gain
+            options.
+        """
+        gain_manager.gain_option_add(self)
+
+
+class GainOptions(object):
+    """
+    Manages a set of gain options.
+    """
+    gain_options = {}  # Dictionary of gain options
+
+    _selected_gain = None  # The selected gain option. Must be a key of the
+    # gain_options dictionary.
+
+    @property
+    def gains(self):
+        """
+        Returns:
+            list(str): gain options to be shown in view.
+        """
+        return list(self.gain_options)
+
+    @property
+    def selected_gain(self):
+        """
+        Returns:
+            GainSetting: The selected gain setting.
+        """
+        return self.gain_options[self._selected_gain]
+
+    @selected_gain.setter
+    def selected_gain(self, selected_gain):
+        """
+        Sets the selected gain option.
+
+        Args:
+            selected_gain (str): The gain option, which must be a key from
+            the internal gain_options dictionary.
+        """
+        if selected_gain not in self.gain_options:
+            raise ValueError("Requested acquisition gain '{}' is not one of "
+                             "'{}'".format(selected_gain,
+                                           self.gain_options))
+        self._selected_gain = selected_gain
+
+    def __init__(self):
+        """
+        Creates gain options to be managed.
+        """
+        gain_options = [
+            GainSetting("1 V/div", 1000, 1, 4),
+            GainSetting("0.5 V/div", 500, 1, 8),
+            GainSetting("0.2 V/div", 200, 10, 2),
+            GainSetting("0.1 V/div", 100, 10, 4),
+            GainSetting("50 mV/div", 50, 10, 8),
+            GainSetting("20 mV/div", 20, 10, 16),
+            GainSetting("10 mV/div", 10, 10, 32)
+        ]
+
+        for gain_option in gain_options:
+            gain_option.add_to_gain_options(self)
+
+    def gain_option_add(self, gain_option):
+        """
+        Add a gain option to this gain manager.
+
+        Args:
+            gain_option (GainSetting): One particular gain option.
+        """
+        self.gain_options.update({gain_option.display_str: gain_option})

--- a/dpscope/controller/helper/gain_setting.py
+++ b/dpscope/controller/helper/gain_setting.py
@@ -130,3 +130,18 @@ class GainOptions(object):
             gain_option (GainSetting): One particular gain option.
         """
         self.gain_options.update({gain_option.display_str: gain_option})
+
+
+class GainManager(object):
+    """
+    Gain settings manager for the dual channel device.
+    """
+    ch1 = None  # Channel 1 gain options
+    ch2 = None  # Channel 2 gain options
+
+    def __init__(self):
+        """
+        Creates gain options for the 2 channels.
+        """
+        self.ch1 = GainOptions()
+        self.ch2 = GainOptions()

--- a/dpscope/controller/observer.py
+++ b/dpscope/controller/observer.py
@@ -200,3 +200,35 @@ class SampleSpeedObserver(ViewObserverBase):
         self._model.stream_period_set(stream_period)
         # Reset plot
         self._view.observers_notify("Acquisition.Clear")
+
+
+class GainCh1Observer(ViewObserverBase):
+    """
+    Reacts to changes in Channel 1 gain.
+    """
+    channel = "Vertical.ch1gain"
+
+    def update(self):
+        gain_settings = self._view.gain_options.ch1
+        gain_settings.selected_gain = self._view.signals[self.channel].get()
+        selected_gain = gain_settings.selected_gain
+        _LOGGER.info("Ch1 gain '{}' selected from app."
+                     "".format(selected_gain.display_str))
+        self._model.gain_set(0, selected_gain.gain)
+        self._model.pregain_set(0, selected_gain.pregain)
+
+
+class GainCh2Observer(ViewObserverBase):
+    """
+    Reacts to changes in Channel 2 gain.
+    """
+    channel = "Vertical.ch2gain"
+
+    def update(self):
+        gain_settings = self._view.gain_options.ch2
+        gain_settings.selected_gain = self._view.signals[self.channel].get()
+        selected_gain = gain_settings.selected_gain
+        _LOGGER.info("Ch2 gain '{}' selected from app."
+                     "".format(selected_gain.display_str))
+        self._model.gain_set(1, selected_gain.gain)
+        self._model.pregain_set(1, selected_gain.pregain)

--- a/dpscope/gui.py
+++ b/dpscope/gui.py
@@ -14,9 +14,5 @@ if __name__ == "__main__":
             # defaults
             dpscope.trigger.source = TriggerSource.auto
             dpscope.voltages.resolution = VoltageResolution.low
-            dpscope.gain_set(0, 0)
-            dpscope.gain_set(1, 0)
-            dpscope.pregain_set(0, 0)
-            dpscope.pregain_set(1, 0)
 
             app.show()

--- a/dpscope/model/controller/__init__.py
+++ b/dpscope/model/controller/__init__.py
@@ -122,11 +122,11 @@ class DPScopeController(object):
             ch (int): Channel number (0 or 1).
             gain_factor (int): Gain factor for the requested channel.
         """
-        # Sends DPScope command for setting the gain
-        self._interface.gain(ch, gain_factor)
         # Set gain factor value in logic
         gain_convert = Gain()
         gain_code = gain_convert.val_to_code(gain_factor)
+        # Sends DPScope command for setting the gain
+        self._interface.gain(ch, gain_code)
         try:
             self.voltages.gain[ch] = gain_factor
             _LOGGER.info("Setting channel '{}' gain code to '{}' (x{})"
@@ -168,11 +168,11 @@ class DPScopeController(object):
             ch (int): Channel number (0 or 1).
             pregain_factor (int): Pregain factor for the requested channel.
         """
-        # Sends DPScope command to set pregain.
-        self._interface.pre_gain(ch, pregain_factor)
         # Set pregain code in logic.
         pregain_convert = PreGain()
         pregain_code = pregain_convert.val_to_code(pregain_factor)
+        # Sends DPScope command to set pregain.
+        self._interface.pre_gain(ch, pregain_code)
         try:
             self.voltages.pregain[ch] = pregain_factor
             _LOGGER.info("Setting channel '{}' pre-gain code to '{}' (x{})"

--- a/dpscope/model/controller/__init__.py
+++ b/dpscope/model/controller/__init__.py
@@ -110,15 +110,9 @@ class DPScopeController(object):
         Returns:
             int: Gain factor for the requested channel.
         """
-        try:
-            if self.voltages.gain[ch] is None:
-                self.gain_set(ch, 1)
-        except IndexError as ie:
-            raise ie("Attempting to set gain on channel {}; Channel "
-                     "specifier can only be (0, 1).".format(ch))
         return self.voltages.gain[ch]
 
-    def gain_set(self, ch, gain):
+    def gain_set(self, ch, gain_factor):
         """
         Sets gain into DPScope.
 
@@ -126,17 +120,17 @@ class DPScopeController(object):
 
         Args:
             ch (int): Channel number (0 or 1).
-            gain (int): Gain code for the requested channel.
+            gain_factor (int): Gain factor for the requested channel.
         """
         # Sends DPScope command for setting the gain
-        self._interface.gain(ch, gain)
+        self._interface.gain(ch, gain_factor)
         # Set gain factor value in logic
         gain_convert = Gain()
-        gain_factor = gain_convert.code_to_val(gain)
+        gain_code = gain_convert.val_to_code(gain_factor)
         try:
             self.voltages.gain[ch] = gain_factor
             _LOGGER.info("Setting channel '{}' gain code to '{}' (x{})"
-                         "".format(ch, gain, gain_factor))
+                         "".format(ch, gain_code, gain_factor))
         except IndexError as ie:
             raise ie("Attempting to set gain on channel {}; Channel "
                      "specifier can only be (0, 1).".format(ch))
@@ -162,15 +156,9 @@ class DPScopeController(object):
         Returns:
             int: Pregain factor for the requested channel.
         """
-        try:
-            if self.voltages.pregain[ch] is None:
-                self.pregain_set(ch, 1)
-        except IndexError as ie:
-            raise ie("Attempting to set gain on channel {}; Channel "
-                     "specifier can only be (0, 1).".format(ch))
         return self.voltages.pregain[ch]
 
-    def pregain_set(self, ch, pregain):
+    def pregain_set(self, ch, pregain_factor):
         """
         Sets pregain into DPScope.
 
@@ -178,17 +166,17 @@ class DPScopeController(object):
 
         Args:
             ch (int): Channel number (0 or 1).
-            pregain (int): Pregain code for the requested channel.
+            pregain_factor (int): Pregain factor for the requested channel.
         """
         # Sends DPScope command to set pregain.
-        self._interface.pre_gain(ch, pregain)
+        self._interface.pre_gain(ch, pregain_factor)
         # Set pregain code in logic.
         pregain_convert = PreGain()
-        pregain_factor = pregain_convert.code_to_val(pregain)
+        pregain_code = pregain_convert.val_to_code(pregain_factor)
         try:
             self.voltages.pregain[ch] = pregain_factor
             _LOGGER.info("Setting channel '{}' pre-gain code to '{}' (x{})"
-                         "".format(ch, pregain, pregain_factor))
+                         "".format(ch, pregain_code, pregain_factor))
         except IndexError as ie:
             raise ie("Attempting to set gain on channel {}; Channel "
                      "specifier can only be (0, 1).".format(ch))

--- a/dpscope/model/controller/helper/gain.py
+++ b/dpscope/model/controller/helper/gain.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/dpscope/model/controller/helper/voltage_measure.py
+++ b/dpscope/model/controller/helper/voltage_measure.py
@@ -127,7 +127,7 @@ class VoltageSingleRead(object):
         voltages = []
         for ch, adc in enumerate(adc_vals):
             multiplier = ((max_V * pot_ratio / max_adc)
-                          * (self.pregain[ch]*self.gain[ch]))
+                          / (self.pregain[ch]*self.gain[ch]))
             voltages.append(multiplier * adc)
 
         return voltages

--- a/dpscope/model/controller/helper/voltage_measure.py
+++ b/dpscope/model/controller/helper/voltage_measure.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from enum import Enum
 from functools import total_ordering
 import logging
@@ -85,36 +86,49 @@ class VoltageSingleRead(object):
             already been calculated).
         """
         if not self._usb_voltage:
-            old_res = self.resolution
             dac_mV = 3000
-            self.resolution = VoltageResolution.high
-            ch_indices = [0, 1]
-            # The Set DAC DPScope commands actually works different from
-            # documentation.
-            for ch in ch_indices:
-                self._interface.set_dac(ch, dac_mV)
-                self._interface.pre_gain(ch, 0)
-                self._interface.gain(ch, 0)
-            adcs = self._interface.measure_offset()
+            with self._usb_context(dac_mV):
+                adcs = self._interface.measure_offset()
             real_dac = sum(adcs) / 2
             _LOGGER.info("Measured ADC offsets = '{}' for DAC output = '{}"
                          "mV'".format(adcs, dac_mV))
-            gain_convert = Gain()
-            pregain_convert = PreGain()
-            for ch in ch_indices:
-                self._interface.set_dac(ch, 0)
-                self._interface.pre_gain(ch, pregain_convert.val_to_code(
-                    self.pregain[ch]))
-                self._interface.gain(ch, gain_convert.val_to_code(
-                    self.gain[ch]))
             nominal_dac = float(dac_mV)/1000 * (256 / 1.25)
             self._usb_voltage = 5. * (nominal_dac / real_dac)
             _LOGGER.info("Real USB voltage measured to be {}."
                          "".format(self._usb_voltage))
-            if old_res != self.resolution:
-                self.resolution = old_res
 
         return self._usb_voltage
+
+    @contextmanager
+    def _usb_context(self, dac_mV):
+        """
+        Saves and restores settings during USB voltage calibration.
+
+        Args:
+            dac_mV (int): The DAC output voltage used for calibration.
+        """
+        old_res = self.resolution
+        self.resolution = VoltageResolution.high
+        ch_indices = [0, 1]
+        # The Set DAC DPScope commands actually works different from
+        # documentation.
+        for ch in ch_indices:
+            self._interface.set_dac(ch, dac_mV)
+            self._interface.pre_gain(ch, 0)
+            self._interface.gain(ch, 0)
+
+        yield
+
+        gain_convert = Gain()
+        pregain_convert = PreGain()
+        for ch in ch_indices:
+            self._interface.set_dac(ch, 0)
+            self._interface.pre_gain(ch, pregain_convert.val_to_code(
+                self.pregain[ch]))
+            self._interface.gain(ch, gain_convert.val_to_code(
+                self.gain[ch]))
+        if old_res != self.resolution:
+            self.resolution = old_res
 
     def read(self):
         """

--- a/dpscope/view/base.py
+++ b/dpscope/view/base.py
@@ -49,6 +49,7 @@ class View(object):
 
     initialiser = None  # Manager for intialising this view.
     acq_rate = None  # Manager for controlling acquisition rates.
+    gain_options = None  # Manager for controlling measurement gains.
 
     @property
     def plot_mode(self):

--- a/dpscope/view/builder/standard.py
+++ b/dpscope/view/builder/standard.py
@@ -134,6 +134,7 @@ class StandardViewBuilder(ViewBuilderBase):
     _ctrl_right = None
 
     _acq_rate_controller = None
+    _gain_controller = None
 
     @classmethod
     def _make_name(cls, container, input_label):
@@ -150,15 +151,18 @@ class StandardViewBuilder(ViewBuilderBase):
         """
         return "{}.{}".format(container["text"], input_label)
 
-    def __init__(self, acq_rate_ctrl):
+    def __init__(self, acq_rate_ctrl, gain_ctrl):
         """
-        Instantiate with converter for acquistion rate setting.
+        Instantiate with converter for acquisition rate setting.
 
         Args:
             acq_rate_ctrl (AcquisitionRate): Manager for controlling data
             acquisition rates.
+            gain_ctrl (GainOptions): The gain controller that maps gain
+            options shown in view to DPScope gain settings.
         """
         self._acq_rate_controller = acq_rate_ctrl
+        self._gain_controller = gain_ctrl
 
     def _add_button(self, container, label):
         """
@@ -345,6 +349,8 @@ class StandardViewBuilder(ViewBuilderBase):
         self._view.vert_ctrl = LabelFrame(self._ctrl_right, text="Vertical")
         self._view.vert_ctrl.pack(fill=BOTH, expand=1)
 
+        self._view.gain_options = self._gain_controller
+
         gains = ["1 V/div", "0.5 V/div", "0.2 V/div", "0.1 V/div", "50 mV/div",
                  "20 mV/div", "10 mV/div", "5 mV/div"]
         Label(self._view.vert_ctrl, text="Scale").grid(sticky=W, row=0,
@@ -354,13 +360,15 @@ class StandardViewBuilder(ViewBuilderBase):
                                              columnspan=2)
         Label(self._view.vert_ctrl, text="Ch1").grid(sticky=W, row=2, column=0)
 
-        self._add_option_menu(self._view.vert_ctrl, "ch1gain", gains, 2, 1)
+        self._add_option_menu(self._view.vert_ctrl, "ch1gain",
+                              self._view.gain_options.gains, 2, 1)
         ch1att_options = [RadioBtnSubOptions("1:1", 2, 2),
                           RadioBtnSubOptions("1:10", 2, 3)]
         self._add_radio_button(self._view.vert_ctrl, "ch1att", ch1att_options)
 
         Label(self._view.vert_ctrl, text="Ch2").grid(sticky=W, row=4, column=0)
-        self._add_option_menu(self._view.vert_ctrl, "ch2gain", gains, 4, 1)
+        self._add_option_menu(self._view.vert_ctrl, "ch2gain",
+                              self._view.gain_options.gains, 4, 1)
         ch2att_options = [RadioBtnSubOptions("1:1", 4, 2),
                           RadioBtnSubOptions("1:10", 4, 3)]
         self._add_radio_button(self._view.vert_ctrl, "ch2att", ch2att_options)

--- a/dpscope/view/builder/standard.py
+++ b/dpscope/view/builder/standard.py
@@ -158,7 +158,7 @@ class StandardViewBuilder(ViewBuilderBase):
         Args:
             acq_rate_ctrl (AcquisitionRate): Manager for controlling data
             acquisition rates.
-            gain_ctrl (GainOptions): The gain controller that maps gain
+            gain_ctrl (GainManager): The gain controller that maps gain
             options shown in view to DPScope gain settings.
         """
         self._acq_rate_controller = acq_rate_ctrl
@@ -234,7 +234,6 @@ class StandardViewBuilder(ViewBuilderBase):
                    command=
                    lambda x: self._view.observers_notify(signal_name)
                    ).grid(sticky=W, row=row, column=column, **grid_opt)
-        self._view.signals[signal_name].set(options[0])
         _LOGGER.debug("Added option menu '{}' with accompanying signal and "
                       "observer queue.".format(signal_name))
 
@@ -359,14 +358,14 @@ class StandardViewBuilder(ViewBuilderBase):
         Label(self._view.vert_ctrl, text="Ch1").grid(sticky=W, row=2, column=0)
 
         self._add_option_menu(self._view.vert_ctrl, "ch1gain",
-                              self._view.gain_options.gains, 2, 1)
+                              self._view.gain_options.ch1.gains, 2, 1)
         ch1att_options = [RadioBtnSubOptions("1:1", 2, 2),
                           RadioBtnSubOptions("1:10", 2, 3)]
         self._add_radio_button(self._view.vert_ctrl, "ch1att", ch1att_options)
 
         Label(self._view.vert_ctrl, text="Ch2").grid(sticky=W, row=4, column=0)
         self._add_option_menu(self._view.vert_ctrl, "ch2gain",
-                              self._view.gain_options.gains, 4, 1)
+                              self._view.gain_options.ch2.gains, 4, 1)
         ch2att_options = [RadioBtnSubOptions("1:1", 4, 2),
                           RadioBtnSubOptions("1:10", 4, 3)]
         self._add_radio_button(self._view.vert_ctrl, "ch2att", ch2att_options)

--- a/dpscope/view/builder/standard.py
+++ b/dpscope/view/builder/standard.py
@@ -351,8 +351,6 @@ class StandardViewBuilder(ViewBuilderBase):
 
         self._view.gain_options = self._gain_controller
 
-        gains = ["1 V/div", "0.5 V/div", "0.2 V/div", "0.1 V/div", "50 mV/div",
-                 "20 mV/div", "10 mV/div", "5 mV/div"]
         Label(self._view.vert_ctrl, text="Scale").grid(sticky=W, row=0,
                                                        column=1)
         Label(self._view.vert_ctrl,

--- a/dpscope/view/helper/initialise.py
+++ b/dpscope/view/helper/initialise.py
@@ -6,7 +6,8 @@ from inspect import getmembers, isclass, isabstract
 import logging
 import sys
 
-from view.helper.plot_modes import TimePlot
+from controller.helper.acquisition_rate import AcquisitionRate
+from controller.helper.gain_setting import GainOptions
 
 # Set up logging
 logging.basicConfig(level=logging.DEBUG)
@@ -105,4 +106,10 @@ class StandardInitialiser(ViewInitialiserBase):
         self._signal_and_notify("Display.Ch1", True)
         self._signal_and_notify("Display.Ch2", True)
 
+        default_gains = GainOptions().gains[0]
+        self._signal_and_notify("Vertical.ch1gain", default_gains)
+        self._signal_and_notify("Vertical.ch2gain", default_gains)
+
         self._signal_and_notify("Horizontal.sample_mode", "Scope mode")
+        default_acq_rate = AcquisitionRate().speeds[-1]
+        self._signal_and_notify("Horizontal.sample_speed", default_acq_rate)


### PR DESCRIPTION
- Scope can be set to measure at various gains.
- Fixed some voltage scaling issues during voltage measurements.
- Fixed how USB voltage is measured (settings are saved and restored)
- Time resolution default is set on connecting to scope.